### PR TITLE
Add templates for summit 13

### DIFF
--- a/src/components/oc6-oculus-210f/signage/screen.vue
+++ b/src/components/oc6-oculus-210f/signage/screen.vue
@@ -244,7 +244,7 @@
         color: rgb(183,236,0);
     }
     .room-668 {
-        background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-210f")!important;
+        background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-210f.png")!important;
     }
     .room-668 h1.time {
         color: rgb(255,186,0);

--- a/src/components/oc6-oculus-210h/signage/screen.vue
+++ b/src/components/oc6-oculus-210h/signage/screen.vue
@@ -244,7 +244,7 @@
         color: rgb(183,236,0);
     }
     .room-668 {
-        background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-210h")!important;
+        background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-210h.png")!important;
     }
     .room-668 h1.time {
         color: rgb(255,186,0);

--- a/src/components/oc6-oculus-220b/signage/screen.vue
+++ b/src/components/oc6-oculus-220b/signage/screen.vue
@@ -244,7 +244,7 @@
         color: rgb(183,236,0);
     }
     .room-668 {
-        background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-220b")!important;
+        background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-220b.png")!important;
     }
     .room-668 h1.time {
         color: rgb(255,186,0);

--- a/templates/fntech/13/oc6-oculus-image-eod1.html
+++ b/templates/fntech/13/oc6-oculus-image-eod1.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC6 EOD Static Image Day 1</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-image-eod1.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-image-eod2.html
+++ b/templates/fntech/13/oc6-oculus-image-eod2.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC6 EOD Static Image Day 2</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-image-eod2.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-image-sessionfull.html
+++ b/templates/fntech/13/oc6-oculus-image-sessionfull.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC6 Static Image Session Full</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-image-sessionfull.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-registration-thu.html
+++ b/templates/fntech/13/oc6-oculus-registration-thu.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC6 OCULUS Registration thu</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+		background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-thu.png");
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-registration-thu.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-registration-wed.html
+++ b/templates/fntech/13/oc6-oculus-registration-wed.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC6 OCULUS Registration wed</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+		background-image: url("~/assets/images/oc6-oculus/OC6_FNSIGN_Bkgd-wed.png");
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-registration-wed.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-registration.html
+++ b/templates/fntech/13/oc6-oculus-registration.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC6 OCULUS Registration</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+		background-image: url("~/assets/images/oc5-oculus/OC6_FNSIGN_Bkgd_LMU_edit.png");
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-registration.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-signage-210f.html
+++ b/templates/fntech/13/oc6-oculus-signage-210f.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC5 OCULUS Signage 210f</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-signage-210f.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-signage-210h.html
+++ b/templates/fntech/13/oc6-oculus-signage-210h.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC5 OCULUS Signage 210h</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-signage-210h.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-signage-220b.html
+++ b/templates/fntech/13/oc6-oculus-signage-220b.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC5 OCULUS Signage 220b</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-signage-220b.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-signage-220c.html
+++ b/templates/fntech/13/oc6-oculus-signage-220c.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC5 OCULUS Signage 220c</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-signage-220c.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-signage-sp.html
+++ b/templates/fntech/13/oc6-oculus-signage-sp.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC5 OCULUS Signage sp</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-signage-sp.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/oc6-oculus-signage-tt.html
+++ b/templates/fntech/13/oc6-oculus-signage-tt.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OC5 OCULUS Signage 210h</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="manifest" href="/assets/favicon/manifest.json">
+    <link rel="mask-icon" href="/assets/favicon/safari-pinned-tab.svg" color="#5bbad5">
+
+    <style type="text/css">
+        @font-face {
+            font-family: Oculus Sans;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Regular.otf") format('opentype');
+        }
+        @font-face {
+            font-family: Oculus Sans;
+            font-weight: bold;
+            src: url("/assets/fonts/oculus-sans/OculusSans-Bold.otf") format('opentype');
+        }
+    </style>
+
+    <style>
+      body {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #808080;		
+      }
+      .fill pre {
+        color: white;
+      }   
+      .fill pre {
+        color: white;
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+    <script src="/dist/manifest.build.js"></script>
+    <script src="/dist/commons.build.js"></script>
+    <script src="/dist/oc6-oculus-signage-210h.build.js"></script>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2022-empowering-open.html.html
+++ b/templates/fntech/13/ocp-2022-empowering-open.html.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2022 Empowering Open</title>
+    
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #191A4F;
+        background-image: url('assets/images/ocp-2022/empowering-open.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2022-expo-hall-talks.html.html
+++ b/templates/fntech/13/ocp-2022-expo-hall-talks.html.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2022 Expo Hall Talks</title>
+
+    <script>
+      (function() {
+        var config = {
+          kitId: 'tde8ron'
+        };
+        var d = false;
+        var tk = document.createElement('script');
+        tk.src = '//use.typekit.net/' + config.kitId + '.js';
+        tk.type = 'text/javascript';
+        tk.async = 'true';
+        tk.onload = tk.onreadystatechange = function() {
+          var rs = this.readyState;
+          if (d || rs && rs != 'complete' && rs != 'loaded') return;
+          d = true;
+          try { Typekit.load(config); } catch (e) {}
+        };
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(tk, s);
+      })();
+    </script>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #191A4F;
+        background-image: url('assets/images/ocp-2022/background.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2022-session-full.html
+++ b/templates/fntech/13/ocp-2022-session-full.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2022 Session Full</title>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #191A4F;
+        background-image: url('assets/images/ocp-2022/session-full.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2022.html
+++ b/templates/fntech/13/ocp-2022.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2022</title>
+
+    <script>
+      (function() {
+        var config = {
+          kitId: 'tde8ron'
+        };
+        var d = false;
+        var tk = document.createElement('script');
+        tk.src = '//use.typekit.net/' + config.kitId + '.js';
+        tk.type = 'text/javascript';
+        tk.async = 'true';
+        tk.onload = tk.onreadystatechange = function() {
+          var rs = this.readyState;
+          if (d || rs && rs != 'complete' && rs != 'loaded') return;
+          d = true;
+          try { Typekit.load(config); } catch (e) {}
+        };
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(tk, s);
+      })();
+    </script>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #191A4F;
+        background-image: url('assets/images/ocp-2022/background.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2023-expo-hall-talks.html
+++ b/templates/fntech/13/ocp-2023-expo-hall-talks.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2023 Expo Hall Talks</title>
+
+    <script>
+      (function() {
+        var config = {
+          kitId: 'tde8ron'
+        };
+        var d = false;
+        var tk = document.createElement('script');
+        tk.src = '//use.typekit.net/' + config.kitId + '.js';
+        tk.type = 'text/javascript';
+        tk.async = 'true';
+        tk.onload = tk.onreadystatechange = function() {
+          var rs = this.readyState;
+          if (d || rs && rs != 'complete' && rs != 'loaded') return;
+          d = true;
+          try { Typekit.load(config); } catch (e) {}
+        };
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(tk, s);
+      })();
+    </script>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      body {
+        margin: 0px;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #000000;
+        background-image: url('assets/images/ocp-2023/OCP23G_FNSIGN_Bkgd.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2023-scaling-innovation.html
+++ b/templates/fntech/13/ocp-2023-scaling-innovation.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2023 Empowering Open</title>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      body {
+        margin: 0px;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #000000;
+        background-image: url('assets/images/ocp-2023/OCP23G_FNSIGN_Placeholder.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2023-session-full-live.html
+++ b/templates/fntech/13/ocp-2023-session-full-live.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2023 Session Full</title>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      body {
+        margin: 0px;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #000000;
+        background-image: url('assets/images/ocp-2023/OCP23G_FNSIGN_Session-Full-Overflow.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2023-session-full.html
+++ b/templates/fntech/13/ocp-2023-session-full.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2023 Session Full</title>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      body {
+        margin: 0px;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #000000;
+        background-image: url('assets/images/ocp-2023/OCP23G_FNSIGN_Session-Full.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>

--- a/templates/fntech/13/ocp-2023.html
+++ b/templates/fntech/13/ocp-2023.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<meta http-equiv="Cache-Control" content="no-store, must-revalidate" />
+	<meta http-equiv="Expires" content="0" />
+
+    <title>OCP 2023</title>
+
+    <script>
+      (function() {
+        var config = {
+          kitId: 'tde8ron'
+        };
+        var d = false;
+        var tk = document.createElement('script');
+        tk.src = '//use.typekit.net/' + config.kitId + '.js';
+        tk.type = 'text/javascript';
+        tk.async = 'true';
+        tk.onload = tk.onreadystatechange = function() {
+          var rs = this.readyState;
+          if (d || rs && rs != 'complete' && rs != 'loaded') return;
+          d = true;
+          try { Typekit.load(config); } catch (e) {}
+        };
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(tk, s);
+      })();
+    </script>
+
+    <style>
+      body > * {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+      }
+      body {
+        margin: 0px;
+      }
+      .fill {
+        height: 1920px; 
+        width: 1080px;
+        background-size: contain;
+        background-repeat: no-repeat;
+        background-color: #000000;
+        background-image: url('assets/images/ocp-2023/OCP23G_FNSIGN_Bkgd.png');
+      }
+    </style>
+  </head>
+  <body class="fill">
+    <div id="app"></div>
+  </body>
+</html>


### PR DESCRIPTION
* Includes a fix for oc6 templates, some vue files had a missing import for the background 

ref: https://tipit.avaza.com/task#!sortby=DateUpdatedDesc&task=3567933

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>
